### PR TITLE
add: viada.lt (lukoil)

### DIFF
--- a/stoppropaganda.go
+++ b/stoppropaganda.go
@@ -41,6 +41,7 @@ var links = map[string]struct{}{
 	"https://lt.rubaltic.ru":    {},
 	"http://sputniknews.lt":     {},
 	"https://lv.sputniknews.ru": {},
+        "https://viada.lt":          {},
 
 	/* Russia */
 


### PR DESCRIPTION
Business (gas station) chain in Lithuania. Formerly 'Lukoil Baltija'. https://en.wikipedia.org/wiki/Lukoil_Baltija. Supposedly with rebranding changed, but widely believed (known) to be owned through an "intermediatery" company by Russian owners. 