### PR TITLE
add separate docker-compose for tor capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ docker-compose pull
 
 # Create/recreate container
 docker-compose up -d
+
+# Using tor
+docker-compose -f docker-compose-tor.yaml up -d
 ```
 
 Also see [Docker](#docker) for additional information.

--- a/docker-compose-tor.yaml
+++ b/docker-compose-tor.yaml
@@ -5,9 +5,9 @@ services:
     container_name: stoppropaganda-tor
     restart: unless-stopped
     ports:
-      - "8049:8049/tcp"
+      - "8059:8059/tcp"
     environment:
-      SP_BIND: ":8049"
+      SP_BIND: ":8059"
       SP_WORKERS: "20"
       SP_DNSWORKERS: "100"
       SP_TIMEOUT: "10s"

--- a/docker-compose-tor.yaml
+++ b/docker-compose-tor.yaml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  stoppropaganda-tor:
+    image: erikmnkl/stoppropaganda
+    container_name: stoppropaganda
+    restart: unless-stopped
+    ports:
+      - "8049:8049/tcp"
+    environment:
+      SP_BIND: ":8049"
+      SP_WORKERS: "20"
+      SP_DNSWORKERS: "100"
+      SP_TIMEOUT: "10s"
+      SP_USERAGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
+      HTTPS_PROXY: http://tor:8118
+    ulimits:
+      nofile:
+        soft: 128000
+        hard: 128000
+
+  tor:
+    container_name: tor
+    ports:
+      - 8118:8118
+      - 9050:9050
+    image: avpnusr/torprivoxy
+
+
+

--- a/docker-compose-tor.yaml
+++ b/docker-compose-tor.yaml
@@ -24,6 +24,3 @@ services:
       - 8118:8118
       - 9050:9050
     image: avpnusr/torprivoxy
-
-
-

--- a/docker-compose-tor.yaml
+++ b/docker-compose-tor.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   stoppropaganda-tor:
     image: erikmnkl/stoppropaganda
-    container_name: stoppropaganda
+    container_name: stoppropaganda-tor
     restart: unless-stopped
     ports:
       - "8049:8049/tcp"

--- a/stoppropaganda.go
+++ b/stoppropaganda.go
@@ -433,6 +433,7 @@ func init() {
 	tr := &http.Transport{
 		DisableCompression: true,                                  // Disable automatic decompression
 		TLSClientConfig:    &tls.Config{InsecureSkipVerify: true}, // Disable TLS verification
+                Proxy:              http.ProxyFromEnvironment,
 	}
 	httpClient = http.Client{
 		Timeout:       *flagTimeout,     // Enable timeout


### PR DESCRIPTION
separate 'study example' to utilise 'tor' for shy users. please evaluate if useful.
tried to test utilising simple principle: https://github.com/jozapjapo/thor-nginx-docker-compose-test
results (seems to be okay):
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/100611415/156051271-efb87223-e387-44db-a2bf-c01681ac2eb8.png">
