### PR TITLE
Adding dnstimeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ docker run --name stoppropaganda -d --ulimit nofile=128000:128000 -p "8049:8049/
 Use environment variables to change settings (for example `--env SP_WORKERS=50 SP_DNSWORKERS=500`) to change configuration. Available environment variables (and their defaults):
 ```
 SP_WORKERS="20"
-SP_DNSWORKERS="100"
 SP_TIMEOUT="10s"
+SP_DNSWORKERS="100"
+SP_DNSTIMEOUT="125ms"
 SP_USERAGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
 ```
 
@@ -146,6 +147,7 @@ You can also build for other architectures/platforms as well, see `build.sh` fil
 # Recommendations
 
 * Increase `workers`/`dnsworkers` count from 20/100 (default) to e.g. 100/1000 for greater effect, but check the logs if you are not getting `too many open files`. If so, see [this](https://stackoverflow.com/questions/880557/socket-accept-too-many-open-files).
+* Adjust dnstimeout based on your location.  Eastern America ~125-150ms and in Europe this is likely much lower.  To properly adjust this value, check the /status page and if all queries are "successful", lower this value ~20ms and try again until "success" queries are low and thus "timeout errors" increase.
 * Change `useragent` to yours (used for websites only). See [this](https://www.whatismybrowser.com/detect/what-is-my-user-agent/).
 * General recommendation is to use VPN, but this is not necessary. Remember - DOS/DDOS is **illegal**.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,9 @@ services:
       - "8049:8049/tcp"
     environment:
       SP_WORKERS: "20"
-      SP_DNSWORKERS: "100"
       SP_TIMEOUT: "10s"
+      SP_DNSWORKERS: "100"
+      SP_DNSTIMEOUT: "125ms"
       SP_USERAGENT: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
     ulimits:
       nofile:

--- a/internal/stoppropaganda/dns.go
+++ b/internal/stoppropaganda/dns.go
@@ -30,7 +30,7 @@ type DNSServer struct {
 func (ds *DNSServer) Start(endpoint string) {
 	c := new(dns.Client)
 	c.Dialer = &net.Dialer{
-		Timeout: *flagTimeout,
+		Timeout: *flagDNSTimeout,
 	}
 	questionDomain := getRandomDomain() + "."
 	m := new(dns.Msg)

--- a/internal/stoppropaganda/stoppropaganda.go
+++ b/internal/stoppropaganda/stoppropaganda.go
@@ -19,6 +19,7 @@ var (
 	flagDNSWorkers = fs.Int("dnsworkers", 100, "DOS each DNS server with this amount of workers")
 	flagUserAgent  = fs.String("useragent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36", "User agent used in HTTP requests")
 	flagTimeout    = fs.Duration("timeout", 10*time.Second, "timeout of HTTP request")
+	flagDNSTimeout = fs.Duration("dnstimeout", 10*time.Second, "timeout of DNS request")
 	flagBind       = fs.String("bind", ":8049", "bind on specific host:port")
 )
 

--- a/stoppropaganda.yaml
+++ b/stoppropaganda.yaml
@@ -35,9 +35,11 @@ spec:
           value: ":8049"
         - name: SP_WORKERS
           value: "20"
-        - name: SP_DNSWORKERS
-          value: "100"
         - name: SP_TIMEOUT
           value: "10s"
+        - name: SP_DNSWORKERS
+          value: "100"
+        - name: SP_DNSTIMEOUT
+          value: "125ms"
         - name: SP_USERAGENT
           value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"


### PR DESCRIPTION
This PR is to add an option specific to control the DNS timeout.

From Eastern North America, requests to the Russia DNS servers take ~125-150ms.  Settings the timeout to the actual average response time results mostly in successful queries.

Lowering below the average,  increases "timeout errors" rates while lowering "successful" queries.

I'm not a Go pro and if more changes are needed, let me know.