### PR TITLE
Add rambler.ru and mail.ru

### DIFF
--- a/internal/stoppropaganda/websites.go
+++ b/internal/stoppropaganda/websites.go
@@ -60,6 +60,8 @@ var targetWebsites = map[string]struct{}{
 	"https://regnum.ru":         {},
 	"https://eadaily.com":       {},
 	"https://www.rubaltic.ru":   {},
+	"https://www.rambler.ru":    {},
+	"https://mail.ru":           {},
 
 	// Business corporations
 	"https://www.gazprom.ru":                    {},


### PR DESCRIPTION
Together with yandex they are three most popular Russian websites. Rambler is owned by sberbank and mail.ru has already been sanctioned by Ukraine in the past.