### PR TITLE
Implement socks4, socks5, http proxy

### DIFF
--- a/internal/stoppropaganda/customfasthttptcpdial.go
+++ b/internal/stoppropaganda/customfasthttptcpdial.go
@@ -1,0 +1,470 @@
+package stoppropaganda
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/erkexzcx/stoppropaganda/internal/stoppropaganda/sockshttp"
+	"github.com/valyala/fasthttp"
+)
+
+// Dial dials the given TCP addr using tcp4.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//   * It returns ErrDialTimeout if connection cannot be established during
+//     DefaultDialTimeout seconds. Use DialTimeout for customizing dial timeout.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+//
+// Modified by stoppropaganda contributors only where it's marked:
+// // stoppropaganda start
+// ...
+// // stoppropaganda end
+
+func Dial(addr string) (net.Conn, error) {
+	return defaultDialer.Dial(addr)
+}
+
+// DialTimeout dials the given TCP addr using tcp4 using the given timeout.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+func DialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
+	return defaultDialer.DialTimeout(addr, timeout)
+}
+
+// DialDualStack dials the given TCP addr using both tcp4 and tcp6.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//   * It returns ErrDialTimeout if connection cannot be established during
+//     DefaultDialTimeout seconds. Use DialDualStackTimeout for custom dial
+//     timeout.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+func DialDualStack(addr string) (net.Conn, error) {
+	return defaultDialer.DialDualStack(addr)
+}
+
+// DialDualStackTimeout dials the given TCP addr using both tcp4 and tcp6
+// using the given timeout.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+func DialDualStackTimeout(addr string, timeout time.Duration) (net.Conn, error) {
+	return defaultDialer.DialDualStackTimeout(addr, timeout)
+}
+
+var (
+	defaultDialer = &TCPDialer{Concurrency: 1000}
+)
+
+// Resolver represents interface of the tcp resolver.
+type Resolver interface {
+	LookupIPAddr(context.Context, string) (names []net.IPAddr, err error)
+}
+
+// TCPDialer contains options to control a group of Dial calls.
+type TCPDialer struct {
+	// Concurrency controls the maximum number of concurrent Dials
+	// that can be performed using this object.
+	// Setting this to 0 means unlimited.
+	//
+	// WARNING: This can only be changed before the first Dial.
+	// Changes made after the first Dial will not affect anything.
+	Concurrency int
+
+	// LocalAddr is the local address to use when dialing an
+	// address.
+	// If nil, a local address is automatically chosen.
+	LocalAddr *net.TCPAddr
+
+	// This may be used to override DNS resolving policy, like this:
+	// var dialer = &fasthttp.TCPDialer{
+	// 	Resolver: &net.Resolver{
+	// 		PreferGo:     true,
+	// 		StrictErrors: false,
+	// 		Dial: func (ctx context.Context, network, address string) (net.Conn, error) {
+	// 			d := net.Dialer{}
+	// 			return d.DialContext(ctx, "udp", "8.8.8.8:53")
+	// 		},
+	// 	},
+	// }
+	Resolver Resolver
+
+	// DNSCacheDuration may be used to override the default DNS cache duration (DefaultDNSCacheDuration)
+	DNSCacheDuration time.Duration
+
+	tcpAddrsMap sync.Map
+
+	concurrencyCh chan struct{}
+
+	once sync.Once
+
+	// stoppropaganda start
+	ParentDialer sockshttp.Dialer
+	// stoppropaganda end
+}
+
+// Dial dials the given TCP addr using tcp4.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//   * It returns ErrDialTimeout if connection cannot be established during
+//     DefaultDialTimeout seconds. Use DialTimeout for customizing dial timeout.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+func (d *TCPDialer) Dial(addr string) (net.Conn, error) {
+	return d.dial(addr, false, DefaultDialTimeout)
+}
+
+// DialTimeout dials the given TCP addr using tcp4 using the given timeout.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+func (d *TCPDialer) DialTimeout(addr string, timeout time.Duration) (net.Conn, error) {
+	return d.dial(addr, false, timeout)
+}
+
+// DialDualStack dials the given TCP addr using both tcp4 and tcp6.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//   * It returns ErrDialTimeout if connection cannot be established during
+//     DefaultDialTimeout seconds. Use DialDualStackTimeout for custom dial
+//     timeout.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+func (d *TCPDialer) DialDualStack(addr string) (net.Conn, error) {
+	return d.dial(addr, true, DefaultDialTimeout)
+}
+
+// DialDualStackTimeout dials the given TCP addr using both tcp4 and tcp6
+// using the given timeout.
+//
+// This function has the following additional features comparing to net.Dial:
+//
+//   * It reduces load on DNS resolver by caching resolved TCP addressed
+//     for DNSCacheDuration.
+//   * It dials all the resolved TCP addresses in round-robin manner until
+//     connection is established. This may be useful if certain addresses
+//     are temporarily unreachable.
+//
+// This dialer is intended for custom code wrapping before passing
+// to Client.Dial or HostClient.Dial.
+//
+// For instance, per-host counters and/or limits may be implemented
+// by such wrappers.
+//
+// The addr passed to the function must contain port. Example addr values:
+//
+//     * foobar.baz:443
+//     * foo.bar:80
+//     * aaa.com:8080
+func (d *TCPDialer) DialDualStackTimeout(addr string, timeout time.Duration) (net.Conn, error) {
+	return d.dial(addr, true, timeout)
+}
+
+func (d *TCPDialer) dial(addr string, dualStack bool, timeout time.Duration) (net.Conn, error) {
+	d.once.Do(func() {
+		if d.Concurrency > 0 {
+			d.concurrencyCh = make(chan struct{}, d.Concurrency)
+		}
+
+		if d.DNSCacheDuration == 0 {
+			d.DNSCacheDuration = DefaultDNSCacheDuration
+		}
+
+		go d.tcpAddrsClean()
+	})
+
+	addrs, idx, err := d.getTCPAddrs(addr, dualStack)
+	if err != nil {
+		return nil, err
+	}
+	network := "tcp4"
+	if dualStack {
+		network = "tcp"
+	}
+
+	var conn net.Conn
+	n := uint32(len(addrs))
+	deadline := time.Now().Add(timeout)
+	for n > 0 {
+		conn, err = d.tryDial(network, &addrs[idx%n], deadline, d.concurrencyCh)
+		if err == nil {
+			return conn, nil
+		}
+		if err == ErrDialTimeout {
+			return nil, err
+		}
+		idx++
+		n--
+	}
+	return nil, err
+}
+
+func (d *TCPDialer) tryDial(network string, addr *net.TCPAddr, deadline time.Time, concurrencyCh chan struct{}) (net.Conn, error) {
+	timeout := -time.Since(deadline)
+	if timeout <= 0 {
+		return nil, ErrDialTimeout
+	}
+
+	if concurrencyCh != nil {
+		select {
+		case concurrencyCh <- struct{}{}:
+		default:
+			tc := fasthttp.AcquireTimer(timeout)
+			isTimeout := false
+			select {
+			case concurrencyCh <- struct{}{}:
+			case <-tc.C:
+				isTimeout = true
+			}
+			fasthttp.ReleaseTimer(tc)
+			if isTimeout {
+				return nil, ErrDialTimeout
+			}
+		}
+		defer func() { <-concurrencyCh }()
+	}
+	// stoppropaganda start - add parent dialer
+
+	dialer := d.ParentDialer
+	if dialer == nil {
+		ndialer := &net.Dialer{}
+		if d.LocalAddr != nil {
+			ndialer.LocalAddr = d.LocalAddr
+		}
+		dialer = ndialer
+	}
+
+	conn, err := dialer.Dial(network, addr.String())
+	// stoppropaganda end
+	return conn, err
+}
+
+// ErrDialTimeout is returned when TCP dialing is timed out.
+var ErrDialTimeout = errors.New("dialing to the given TCP address timed out")
+
+// DefaultDialTimeout is timeout used by Dial and DialDualStack
+// for establishing TCP connections.
+const DefaultDialTimeout = 3 * time.Second
+
+type tcpAddrEntry struct {
+	addrs    []net.TCPAddr
+	addrsIdx uint32
+
+	pending     int32
+	resolveTime time.Time
+}
+
+// DefaultDNSCacheDuration is the duration for caching resolved TCP addresses
+// by Dial* functions.
+const DefaultDNSCacheDuration = time.Minute
+
+func (d *TCPDialer) tcpAddrsClean() {
+	expireDuration := 2 * d.DNSCacheDuration
+	for {
+		time.Sleep(time.Second)
+		t := time.Now()
+		d.tcpAddrsMap.Range(func(k, v interface{}) bool {
+			if e, ok := v.(*tcpAddrEntry); ok && t.Sub(e.resolveTime) > expireDuration {
+				d.tcpAddrsMap.Delete(k)
+			}
+			return true
+		})
+
+	}
+}
+
+func (d *TCPDialer) getTCPAddrs(addr string, dualStack bool) ([]net.TCPAddr, uint32, error) {
+	item, exist := d.tcpAddrsMap.Load(addr)
+	e, ok := item.(*tcpAddrEntry)
+	if exist && ok && e != nil && time.Since(e.resolveTime) > d.DNSCacheDuration {
+		// Only let one goroutine re-resolve at a time.
+		if atomic.SwapInt32(&e.pending, 1) == 0 {
+			e = nil
+		}
+	}
+
+	if e == nil {
+		addrs, err := resolveTCPAddrs(addr, dualStack, d.Resolver)
+		if err != nil {
+			item, exist := d.tcpAddrsMap.Load(addr)
+			e, ok = item.(*tcpAddrEntry)
+			if exist && ok && e != nil {
+				// Set pending to 0 so another goroutine can retry.
+				atomic.StoreInt32(&e.pending, 0)
+			}
+			return nil, 0, err
+		}
+
+		e = &tcpAddrEntry{
+			addrs:       addrs,
+			resolveTime: time.Now(),
+		}
+		d.tcpAddrsMap.Store(addr, e)
+	}
+
+	idx := atomic.AddUint32(&e.addrsIdx, 1)
+	return e.addrs, idx, nil
+}
+
+func resolveTCPAddrs(addr string, dualStack bool, resolver Resolver) ([]net.TCPAddr, error) {
+	host, portS, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	port, err := strconv.Atoi(portS)
+	if err != nil {
+		return nil, err
+	}
+
+	if resolver == nil {
+		resolver = net.DefaultResolver
+	}
+
+	ctx := context.Background()
+	ipaddrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	n := len(ipaddrs)
+	addrs := make([]net.TCPAddr, 0, n)
+	for i := 0; i < n; i++ {
+		ip := ipaddrs[i]
+		if !dualStack && ip.IP.To4() == nil {
+			continue
+		}
+		addrs = append(addrs, net.TCPAddr{
+			IP:   ip.IP,
+			Port: port,
+			Zone: ip.Zone,
+		})
+	}
+	if len(addrs) == 0 {
+		return nil, errNoDNSEntries
+	}
+	return addrs, nil
+}
+
+var errNoDNSEntries = errors.New("couldn't find DNS entries for the given domain. Try using DialDualStack")

--- a/internal/stoppropaganda/dialproxy.go
+++ b/internal/stoppropaganda/dialproxy.go
@@ -1,0 +1,104 @@
+package stoppropaganda
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/erkexzcx/stoppropaganda/internal/stoppropaganda/sockshttp"
+)
+
+// func CustomDial(addr string) (conn net.Conn, err error) {
+// 	dialer, err := MakeDialerThrough(proxyChain)
+// 	if err != nil {
+// 		return
+// 	}
+// 	return
+// }
+
+const (
+	ProxyMethodSocks5 = byte(iota)
+	ProxyMethodSocks4
+	ProxyMethodHttp
+	ProxyMethodDirect
+)
+
+func MakeDialerThrough(parentDialer sockshttp.Dialer, proxyChain ProxyChain, proxyTimeout time.Duration) (dialer sockshttp.Dialer) {
+
+	for _, proxy := range proxyChain {
+		proxyaddr := proxy.Addr
+		method := proxy.Method
+		if method == ProxyMethodDirect {
+			// direct
+		} else if method == ProxyMethodHttp {
+			httpd, _ := sockshttp.HTTP("tcp", proxyaddr, dialer)
+			dialer = httpd
+			httpd.(*sockshttp.Http).Timeout = proxyTimeout
+		} else if method == ProxyMethodSocks5 {
+			socks5d, _ := sockshttp.SOCKS5("tcp", proxyaddr, nil, dialer)
+			dialer = socks5d
+			socks5d.(*sockshttp.Socks5).Timeout = proxyTimeout
+		} else if method == ProxyMethodSocks4 {
+			socks4d, _ := sockshttp.SOCKS4("tcp", proxyaddr, nil, dialer)
+			dialer = socks4d
+			socks4d.(*sockshttp.Socks4).Timeout = proxyTimeout
+
+		}
+	}
+
+	return
+}
+
+func MethodName2ID(name string) byte {
+	if name == "socks" || name == "socks5" || name == "5" {
+		return ProxyMethodSocks5
+	}
+	if name == "http" {
+		return ProxyMethodHttp
+	}
+	if name == "socks4" || name == "4" {
+		return ProxyMethodSocks4
+	}
+	return ProxyMethodDirect
+}
+func MethodID2Name(id byte) string {
+	if id == ProxyMethodSocks5 {
+		return "socks5"
+	}
+	if id == ProxyMethodHttp {
+		return "http"
+	}
+	if id == ProxyMethodSocks4 {
+		return "socks4"
+	}
+	return "unknown " + strconv.Itoa(int(id))
+}
+
+type Proxy struct {
+	Addr   string
+	Method byte
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func (this Proxy) String() string {
+	return this.Addr
+}
+
+type ProxyChain []Proxy
+
+func (this ProxyChain) String() string {
+	b := new(strings.Builder)
+	for i, p := range []Proxy(this) {
+		if i != 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(p.Addr)
+	}
+	return b.String()
+}
+func (this ProxyChain) Last() Proxy {
+	return this[len(this)-1]
+}

--- a/internal/stoppropaganda/dialproxy.go
+++ b/internal/stoppropaganda/dialproxy.go
@@ -24,7 +24,7 @@ const (
 )
 
 func MakeDialerThrough(parentDialer sockshttp.Dialer, proxyChain ProxyChain, proxyTimeout time.Duration) (dialer sockshttp.Dialer) {
-
+	dialer = parentDialer
 	for _, proxy := range proxyChain {
 		proxyaddr := proxy.Addr
 		method := proxy.Method

--- a/internal/stoppropaganda/sockshttp/direct.go
+++ b/internal/stoppropaganda/sockshttp/direct.go
@@ -1,0 +1,18 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sockshttp
+
+import (
+	"net"
+)
+
+type direct struct{}
+
+// Direct is a direct proxy: one that makes network connections directly.
+var Direct = direct{}
+
+func (direct) Dial(network, addr string) (net.Conn, error) {
+	return net.Dial(network, addr)
+}

--- a/internal/stoppropaganda/sockshttp/http.go
+++ b/internal/stoppropaganda/sockshttp/http.go
@@ -1,0 +1,90 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sockshttp
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func HTTP(network, addr string, forward Dialer) (Dialer, error) {
+	s := &Http{
+		network: network,
+		addr:    addr,
+		forward: forward,
+	}
+
+	return s, nil
+}
+
+type Http struct {
+	network, addr string
+	forward       Dialer
+	Timeout       time.Duration
+}
+
+func (s *Http) Dial(network, addr string) (net.Conn, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := s.forward.Dial(s.network, s.addr)
+	if err != nil {
+		return nil, err
+	}
+	closeConn := &conn
+	defer func() {
+		if closeConn != nil {
+			(*closeConn).Close()
+		}
+	}()
+	conn.SetDeadline(time.Now().Add(s.Timeout))
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, errors.New("proxy_http: failed to parse port number: " + portStr)
+	}
+	if port < 1 || port > 0xffff {
+		return nil, errors.New("proxy_http: port number out of range: " + portStr)
+	}
+
+	buf := make([]byte, 0, 6+len(host))
+	buf = append(buf, "CONNECT "...)
+	buf = append(buf, addr...)
+	buf = append(buf, " HTTP 1.1\r\n"...)
+	buf = append(buf, "User-agent: Mozilla/4.0\r\n\r\n"...)
+
+	if _, err := conn.Write(buf); err != nil {
+		return nil, errors.New("proxy_http: failed to write CONNECT to HTTP proxy at " + s.addr + ": " + err.Error())
+	}
+	conn.SetDeadline(time.Now().Add(s.Timeout))
+	buf = make([]byte, 2048)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return nil, errors.New("proxy_http: failed to read from HTTP proxy at " + s.addr + ": " + err.Error())
+	}
+	lines := bytes.Split(buf[:n], []byte("\n"))
+	if len(lines) < 0 {
+		return nil, errors.New("proxy_http: received fewer lines from HTTP proxy at " + s.addr)
+	}
+	response := string(lines[0])
+	rcodes := strings.SplitN(response, " ", 3)
+	if len(rcodes) < 3 {
+		return nil, errors.New("proxy_http: received fewer header args from HTTP proxy at " + s.addr)
+	}
+	if !strings.HasPrefix(rcodes[0], "HTTP") {
+		return nil, errors.New("proxy_http: it is not HTTP proxy at " + s.addr)
+	}
+	if !strings.HasPrefix(rcodes[1], "200") {
+		return nil, errors.New("proxy_http: received error code " + rcodes[1] + " HTTP proxy at " + s.addr)
+	}
+	closeConn = nil
+	return conn, nil
+}

--- a/internal/stoppropaganda/sockshttp/http.go
+++ b/internal/stoppropaganda/sockshttp/http.go
@@ -45,8 +45,9 @@ func (s *Http) Dial(network, addr string) (net.Conn, error) {
 			(*closeConn).Close()
 		}
 	}()
-	conn.SetDeadline(time.Now().Add(s.Timeout))
-
+	if s.Timeout > 0 {
+		conn.SetDeadline(time.Now().Add(s.Timeout))
+	}
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		return nil, errors.New("proxy_http: failed to parse port number: " + portStr)
@@ -64,7 +65,9 @@ func (s *Http) Dial(network, addr string) (net.Conn, error) {
 	if _, err := conn.Write(buf); err != nil {
 		return nil, errors.New("proxy_http: failed to write CONNECT to HTTP proxy at " + s.addr + ": " + err.Error())
 	}
-	conn.SetDeadline(time.Now().Add(s.Timeout))
+	if s.Timeout > 0 {
+		conn.SetDeadline(time.Now().Add(s.Timeout))
+	}
 	buf = make([]byte, 2048)
 	n, err := conn.Read(buf)
 	if err != nil {

--- a/internal/stoppropaganda/sockshttp/per_host.go
+++ b/internal/stoppropaganda/sockshttp/per_host.go
@@ -1,0 +1,140 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sockshttp
+
+import (
+	"net"
+	"strings"
+)
+
+// A PerHost directs connections to a default Dialer unless the hostname
+// requested matches one of a number of exceptions.
+type PerHost struct {
+	def, bypass Dialer
+
+	bypassNetworks []*net.IPNet
+	bypassIPs      []net.IP
+	bypassZones    []string
+	bypassHosts    []string
+}
+
+// NewPerHost returns a PerHost Dialer that directs connections to either
+// defaultDialer or bypass, depending on whether the connection matches one of
+// the configured rules.
+func NewPerHost(defaultDialer, bypass Dialer) *PerHost {
+	return &PerHost{
+		def:    defaultDialer,
+		bypass: bypass,
+	}
+}
+
+// Dial connects to the address addr on the given network through either
+// defaultDialer or bypass.
+func (p *PerHost) Dial(network, addr string) (c net.Conn, err error) {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.dialerForRequest(host).Dial(network, addr)
+}
+
+func (p *PerHost) dialerForRequest(host string) Dialer {
+	if ip := net.ParseIP(host); ip != nil {
+		for _, net := range p.bypassNetworks {
+			if net.Contains(ip) {
+				return p.bypass
+			}
+		}
+		for _, bypassIP := range p.bypassIPs {
+			if bypassIP.Equal(ip) {
+				return p.bypass
+			}
+		}
+		return p.def
+	}
+
+	for _, zone := range p.bypassZones {
+		if strings.HasSuffix(host, zone) {
+			return p.bypass
+		}
+		if host == zone[1:] {
+			// For a zone "example.com", we match "example.com"
+			// too.
+			return p.bypass
+		}
+	}
+	for _, bypassHost := range p.bypassHosts {
+		if bypassHost == host {
+			return p.bypass
+		}
+	}
+	return p.def
+}
+
+// AddFromString parses a string that contains comma-separated values
+// specifying hosts that should use the bypass proxy. Each value is either an
+// IP address, a CIDR range, a zone (*.example.com) or a hostname
+// (localhost). A best effort is made to parse the string and errors are
+// ignored.
+func (p *PerHost) AddFromString(s string) {
+	hosts := strings.Split(s, ",")
+	for _, host := range hosts {
+		host = strings.TrimSpace(host)
+		if len(host) == 0 {
+			continue
+		}
+		if strings.Contains(host, "/") {
+			// We assume that it's a CIDR address like 127.0.0.0/8
+			if _, net, err := net.ParseCIDR(host); err == nil {
+				p.AddNetwork(net)
+			}
+			continue
+		}
+		if ip := net.ParseIP(host); ip != nil {
+			p.AddIP(ip)
+			continue
+		}
+		if strings.HasPrefix(host, "*.") {
+			p.AddZone(host[1:])
+			continue
+		}
+		p.AddHost(host)
+	}
+}
+
+// AddIP specifies an IP address that will use the bypass proxy. Note that
+// this will only take effect if a literal IP address is dialed. A connection
+// to a named host will never match an IP.
+func (p *PerHost) AddIP(ip net.IP) {
+	p.bypassIPs = append(p.bypassIPs, ip)
+}
+
+// AddNetwork specifies an IP range that will use the bypass proxy. Note that
+// this will only take effect if a literal IP address is dialed. A connection
+// to a named host will never match.
+func (p *PerHost) AddNetwork(net *net.IPNet) {
+	p.bypassNetworks = append(p.bypassNetworks, net)
+}
+
+// AddZone specifies a DNS suffix that will use the bypass proxy. A zone of
+// "example.com" matches "example.com" and all of its subdomains.
+func (p *PerHost) AddZone(zone string) {
+	if strings.HasSuffix(zone, ".") {
+		zone = zone[:len(zone)-1]
+	}
+	if !strings.HasPrefix(zone, ".") {
+		zone = "." + zone
+	}
+	p.bypassZones = append(p.bypassZones, zone)
+}
+
+// AddHost specifies a hostname that will use the bypass proxy.
+func (p *PerHost) AddHost(host string) {
+	if strings.HasSuffix(host, ".") {
+		host = host[:len(host)-1]
+	}
+	p.bypassHosts = append(p.bypassHosts, host)
+}

--- a/internal/stoppropaganda/sockshttp/proxy.go
+++ b/internal/stoppropaganda/sockshttp/proxy.go
@@ -1,0 +1,98 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package proxy provides support for a variety of protocols to proxy network
+// data.
+package sockshttp
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"os"
+)
+
+// A Dialer is a means to establish a connection.
+type Dialer interface {
+	// Dial connects to the given address via the proxy.
+	Dial(network, addr string) (c net.Conn, err error)
+}
+
+// Auth contains authentication parameters that specific Dialers may require.
+type Auth struct {
+	User, Password string
+}
+
+// FromEnvironment returns the dialer specified by the proxy related variables in
+// the environment.
+func FromEnvironment() Dialer {
+	allProxy := os.Getenv("all_proxy")
+	if len(allProxy) == 0 {
+		return Direct
+	}
+
+	proxyURL, err := url.Parse(allProxy)
+	if err != nil {
+		return Direct
+	}
+	proxy, err := FromURL(proxyURL, Direct)
+	if err != nil {
+		return Direct
+	}
+
+	noProxy := os.Getenv("no_proxy")
+	if len(noProxy) == 0 {
+		return proxy
+	}
+
+	perHost := NewPerHost(proxy, Direct)
+	perHost.AddFromString(noProxy)
+	return perHost
+}
+
+// proxySchemes is a map from URL schemes to a function that creates a Dialer
+// from a URL with such a scheme.
+var proxySchemes map[string]func(*url.URL, Dialer) (Dialer, error)
+
+// RegisterDialerType takes a URL scheme and a function to generate Dialers from
+// a URL with that scheme and a forwarding Dialer. Registered schemes are used
+// by FromURL.
+func RegisterDialerType(scheme string, f func(*url.URL, Dialer) (Dialer, error)) {
+	if proxySchemes == nil {
+		proxySchemes = make(map[string]func(*url.URL, Dialer) (Dialer, error))
+	}
+	proxySchemes[scheme] = f
+}
+
+// FromURL returns a Dialer given a URL specification and an underlying
+// Dialer for it to make network requests.
+func FromURL(u *url.URL, forward Dialer) (Dialer, error) {
+	var auth *Auth
+	if u.User != nil {
+		auth = new(Auth)
+		auth.User = u.User.Username()
+		if p, ok := u.User.Password(); ok {
+			auth.Password = p
+		}
+	}
+
+	switch u.Scheme {
+	case "socks5":
+		return SOCKS5("tcp", u.Host, auth, forward)
+	case "socks4":
+		return SOCKS4("tcp", u.Host, auth, forward)
+	case "http":
+		return HTTP("tcp", u.Host, forward)
+	}
+
+	// If the scheme doesn't match any of the built-in schemes, see if it
+	// was registered by another package.
+	if proxySchemes != nil {
+		if f, ok := proxySchemes[u.Scheme]; ok {
+			return f(u, forward)
+		}
+	}
+
+	return nil, errors.New("proxy: unknown scheme: " + u.Scheme)
+}

--- a/internal/stoppropaganda/sockshttp/socks4.go
+++ b/internal/stoppropaganda/sockshttp/socks4.go
@@ -1,0 +1,150 @@
+package sockshttp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+)
+
+func SOCKS4(network, addr string, auth *Auth, forward Dialer) (Dialer, error) {
+	s := &Socks4{
+		Host:   addr,
+		Auth:   auth,
+		Dialer: forward,
+	}
+
+	return s, nil
+}
+
+// Constants to choose which version of SOCKS protocol to use.
+const (
+	TypeSOCKS4 = iota
+	TypeSOCKS4A
+)
+
+type Socks4 struct {
+	Proto   int
+	Host    string
+	Auth    *Auth
+	Timeout time.Duration
+	Dialer  Dialer
+}
+
+func (cfg *Socks4) Dial(network, forwardAddr string) (net.Conn, error) {
+	socksType := cfg.Proto
+	proxyAddr := cfg.Host
+
+	// dial TCP
+	conn, err := cfg.Dialer.Dial("tcp", proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			conn.Close()
+		}
+	}()
+
+	// connection request
+	host, port, err := splitHostPort16(forwardAddr)
+	if err != nil {
+		return nil, err
+	}
+	ip := net.IPv4(0, 0, 0, 1).To4()
+	if socksType == TypeSOCKS4 {
+		ip, err = lookupIP(host)
+		if err != nil {
+			return nil, err
+		}
+	}
+	req := []byte{
+		4,                          // version number
+		1,                          // command CONNECT
+		byte(port >> 8),            // higher byte of destination port
+		byte(port),                 // lower byte of destination port (big endian)
+		ip[0], ip[1], ip[2], ip[3], // special invalid IP address to indicate the host name is provided
+		0, // user id is empty, anonymous proxy only
+	}
+	if socksType == TypeSOCKS4A {
+		req = append(req, []byte(host+"\x00")...)
+	}
+
+	resp, err := cfg.sendReceive(conn, req)
+	if err != nil {
+		return nil, err
+	} else if len(resp) != 8 {
+		return nil, errors.New("server does not respond properly")
+	}
+	switch resp[1] {
+	case 90:
+		// request granted
+	case 91:
+		return nil, errors.New("socks4: 91 = rejected/failed")
+	case 92:
+		return nil, errors.New("socks4: 92 = client is not running identd (or not reachable from server)")
+	case 93:
+		return nil, errors.New("socks4: 93 = client's identd could not confirm the user ID in the request")
+	default:
+		return nil, fmt.Errorf("socks4: %d = ? unknown error", resp[1])
+	}
+	// clear the deadline before returning
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (c *Socks4) sendReceive(conn net.Conn, req []byte) (resp []byte, err error) {
+	if c.Timeout > 0 {
+		if err := conn.SetWriteDeadline(time.Now().Add(c.Timeout)); err != nil {
+			return nil, err
+		}
+	}
+	_, err = conn.Write(req)
+	if err != nil {
+		return
+	}
+	resp, err = c.readAll(conn)
+	return
+}
+func (c *Socks4) readAll(conn net.Conn) (resp []byte, err error) {
+	resp = make([]byte, 512)
+	if c.Timeout > 0 {
+		if err := conn.SetReadDeadline(time.Now().Add(c.Timeout)); err != nil {
+			return nil, err
+		}
+	}
+	n, err := conn.Read(resp)
+	resp = resp[:n]
+	return
+}
+
+func splitHostPort16(addr string) (host string, port uint16, err error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, err
+	}
+	portInt, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return "", 0, err
+	}
+	port = uint16(portInt)
+	return
+}
+
+func lookupIP(host string) (net.IP, error) {
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("cannot resolve host: %s", host)
+	}
+	ip := ips[0].To4()
+	if len(ip) != net.IPv4len {
+		return nil, errors.New("ipv6 is not supported by SOCKS4")
+	}
+	return ip, nil
+}

--- a/internal/stoppropaganda/sockshttp/socks5.go
+++ b/internal/stoppropaganda/sockshttp/socks5.go
@@ -90,7 +90,9 @@ func (s *Socks5) Dial(network, addr string) (net.Conn, error) {
 			(*closeConn).Close()
 		}
 	}()
-	conn.SetDeadline(time.Now().Add(s.Timeout))
+	if s.Timeout > 0 {
+		conn.SetDeadline(time.Now().Add(s.Timeout))
+	}
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil {

--- a/internal/stoppropaganda/sockshttp/socks5.go
+++ b/internal/stoppropaganda/sockshttp/socks5.go
@@ -1,0 +1,218 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sockshttp
+
+import (
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+// SOCKS5 returns a Dialer that makes SOCKSv5 connections to the given address
+// with an optional username and password. See RFC 1928.
+func SOCKS5(network, addr string, auth *Auth, forward Dialer) (Dialer, error) {
+	s := &Socks5{
+		network: network,
+		addr:    addr,
+		forward: forward,
+	}
+	if auth != nil {
+		s.user = auth.User
+		s.password = auth.Password
+	}
+
+	return s, nil
+}
+
+type Socks5 struct {
+	user, password string
+	network, addr  string
+	forward        Dialer
+	bindaddr       string
+	Timeout        time.Duration
+}
+
+const socks5Version = 5
+
+const (
+	socks5AuthNone     = 0
+	socks5AuthPassword = 2
+)
+
+const socks5Connect = 1
+
+const (
+	socks5IP4    = 1
+	socks5Domain = 3
+	socks5IP6    = 4
+)
+
+var socks5Errors = []string{
+	"",
+	"general failure",
+	"connection forbidden",
+	"network unreachable",
+	"host unreachable",
+	"connection refused",
+	"TTL expired",
+	"command not supported",
+	"address type not supported",
+}
+
+func (s *Socks5) BindAddr() string {
+	return s.bindaddr
+}
+
+// Dial connects to the address addr on the network net via the SOCKS5 proxy.
+func (s *Socks5) Dial(network, addr string) (net.Conn, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	switch network {
+	case "tcp", "tcp6", "tcp4":
+	default:
+		return nil, errors.New("socks5: no support for network " + network)
+	}
+
+	conn, err := s.forward.Dial(s.network, s.addr)
+	if err != nil {
+		return nil, err
+	}
+	closeConn := &conn
+	defer func() {
+		if closeConn != nil {
+			(*closeConn).Close()
+		}
+	}()
+	conn.SetDeadline(time.Now().Add(s.Timeout))
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, errors.New("socks5: failed to parse port number: " + portStr)
+	}
+	if port < 1 || port > 0xffff {
+		return nil, errors.New("socks5: port number out of range: " + portStr)
+	}
+
+	// the size here is just an estimate
+	buf := make([]byte, 0, 6+len(host))
+
+	buf = append(buf, socks5Version)
+	if len(s.user) > 0 && len(s.user) < 256 && len(s.password) < 256 {
+		buf = append(buf, 2 /* num auth methods */, socks5AuthNone, socks5AuthPassword)
+	} else {
+		buf = append(buf, 1 /* num auth methods */, socks5AuthNone)
+	}
+
+	if _, err := conn.Write(buf); err != nil {
+		return nil, errors.New("socks5: write greeting to " + s.addr + ": " + err.Error())
+	}
+
+	if _, err := io.ReadFull(conn, buf[:2]); err != nil {
+		return nil, errors.New("socks5: read greeting from " + s.addr + ": " + err.Error())
+	}
+	/*if buf[0] != 5 {
+	    return nil, errors.New("proxy: SOCKS5 proxy at " + s.addr + " has unexpected version " + strconv.Itoa(int(buf[0])))
+	}*/
+	if buf[1] == 0xff {
+		return nil, errors.New("socks5: " + s.addr + " requires authentication")
+	}
+
+	if buf[1] == socks5AuthPassword {
+		buf = buf[:0]
+		buf = append(buf, 1 /* password protocol version */)
+		buf = append(buf, uint8(len(s.user)))
+		buf = append(buf, s.user...)
+		buf = append(buf, uint8(len(s.password)))
+		buf = append(buf, s.password...)
+
+		if _, err := conn.Write(buf); err != nil {
+			return nil, errors.New("proxy: failed to write authentication request to SOCKS5 proxy at " + s.addr + ": " + err.Error())
+		}
+
+		if _, err := io.ReadFull(conn, buf[:2]); err != nil {
+			return nil, errors.New("proxy: failed to read authentication reply from SOCKS5 proxy at " + s.addr + ": " + err.Error())
+		}
+
+		if buf[1] != 0 {
+			return nil, errors.New("socks5: proxy at " + s.addr + " rejected username/password")
+		}
+	}
+
+	buf = buf[:0]
+	buf = append(buf, socks5Version, socks5Connect, 0 /* reserved */)
+
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			buf = append(buf, socks5IP4)
+			ip = ip4
+		} else {
+			buf = append(buf, socks5IP6)
+		}
+		buf = append(buf, ip...)
+	} else {
+		if len(host) > 255 {
+			return nil, errors.New("proxy: destination hostname too long: " + host)
+		}
+		buf = append(buf, socks5Domain)
+		buf = append(buf, byte(len(host)))
+		buf = append(buf, host...)
+	}
+	buf = append(buf, byte(port>>8), byte(port))
+
+	if _, err := conn.Write(buf); err != nil {
+		return nil, errors.New("socks5: write connect request to " + s.addr + ": " + err.Error())
+	}
+
+	if _, err := io.ReadFull(conn, buf[:4]); err != nil {
+		return nil, errors.New("socks5: read connect reply from " + s.addr + ": " + err.Error())
+	}
+
+	failure := "unknown error"
+	if int(buf[1]) < len(socks5Errors) {
+		failure = socks5Errors[buf[1]]
+	}
+
+	if len(failure) > 0 {
+		return nil, errors.New("socks5: " + s.addr + " failure " + strconv.Itoa(int(buf[1])) + " = " + failure)
+	}
+
+	bytesToDiscard := 0
+	switch buf[3] {
+	case socks5IP4:
+		bytesToDiscard = net.IPv4len
+	case socks5IP6:
+		bytesToDiscard = net.IPv6len
+	case socks5Domain:
+		_, err := io.ReadFull(conn, buf[:1])
+		if err != nil {
+			return nil, errors.New("socks5: read domain length from " + s.addr + ": " + err.Error())
+		}
+		bytesToDiscard = int(buf[0])
+	default:
+		return nil, errors.New("socks5: got unknown address type " + strconv.Itoa(int(buf[3])) + " from " + s.addr)
+	}
+
+	if cap(buf) < bytesToDiscard {
+		buf = make([]byte, bytesToDiscard)
+	} else {
+		buf = buf[:bytesToDiscard]
+	}
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return nil, errors.New("socks5: read address from " + s.addr + ": " + err.Error())
+	}
+	s.bindaddr = string(buf)
+	// Also need to discard the port number
+	if _, err := io.ReadFull(conn, buf[:2]); err != nil {
+		return nil, errors.New("socks5: read port from " + s.addr + ": " + err.Error())
+	}
+
+	closeConn = nil
+	return conn, nil
+}


### PR DESCRIPTION
Example Tor: 
```bash
export all_proxy=socks5://127.0.0.1:9050
./main -workers 1 -dnsworkers 0
```

Socks4:
```bash
export all_proxy=socks4://1.2.3.4:1080
./main -workers 1 -dnsworkers 0
```

Http proxy (auth not supported):
```bash
export all_proxy=http://1.2.3.4:8080
./main -workers 1 -dnsworkers 0
```

We needed to inject our dialer into the `fasthttp.DialFunc`.
Therefore, `customfasthttptcpdial.go` is just modified to accept custom `ParentDialer`.
https://github.com/valyala/fasthttp/blob/1116d034d5354b2975a6089aad66dea00da696f3/tcpdialer.go#L336

Provided code even supports chains:
```golang
proxyChain := []Proxy{
    {"127.0.0.1:9050", ProxyMethodSocks5},
    {"1.2.3.4:9050", ProxyMethodSocks4},
    {"5.6.7.8:9050", ProxyMethodSocks4},
}
```