### PR TITLE
Add ok.ru and its three IPs

### DIFF
--- a/internal/targets/websites.go
+++ b/internal/targets/websites.go
@@ -148,7 +148,11 @@ var TargetWebsites = map[string]struct{}{
 	"https://monopoly.ru":                       {},
 	"https://ul.su":                             {},
 	"http://gruzovozkin.pro":                    {},
-
+	"https://ok.ru":                             {},
+        "http://5.61.23.11":                         {},
+	"http://217.20.155.13":                      {},
+        "http://217.20.147.1":                       {},
+	
 	// Banks
 	"https://www.sberbank.ru":                           {},
 	"https://online.sberbank.ru":                        {},


### PR DESCRIPTION
Please reconsider targeting ok.ru and other Russian social media.
1. ok.ru was already sancioned in May 2017 by President Petro Poroshenko  
2. It is a popular website in Russia and thus paying a lot of taxes from
its ad monetization.
3. It is also a marketplace. In February 2016, the social network, together with its partner bank VTB 24, introduced the ability to make money transfers between users of the network. Transfers are made between MasterCard, Maestro, Visa payment cards issued by Russian banks and linked to user profiles. DDOSing it would hit Russians hard.
4. It is probably as surveiled as VK is. To coordinate against Putin one would prefer something like Matrix or Signal rather than OK.ru or VK.
5. Request to target Ok.ru was posted today by IT Army of Ukraine.


Reference: https://en.wikipedia.org/wiki/Odnoklassniki#Service_blocking_in_Ukraine, IT Army of Ukraine